### PR TITLE
Raise error before jobs getting stuck in  CREATING STACK cfn-airflow-…

### DIFF
--- a/deploy_docker.py
+++ b/deploy_docker.py
@@ -16,6 +16,9 @@ ECR_REPO_NAME = f'airflow-{ENVIRONMENT}'
 IMAGE_TAG = 'latest'
 
 
+class DockerException(Exception): pass
+
+
 def connect_to_ecr():
     client = boto3.client('ecr')
     token = client.get_authorization_token()
@@ -47,6 +50,10 @@ def tag_and_push_to_ecr(image, tag):
     ecr_repo_name = '{}/{}'.format(registry.replace('https://', ''), ECR_REPO_NAME)
     image.tag(ecr_repo_name, tag)
     push_log = docker_client.images.push(ecr_repo_name, tag=tag)
+
+    if 'errorDetail' in push_log:
+        logging.error(push_log)
+        raise DockerException()
     logging.info(push_log)
 
 

--- a/service.yml
+++ b/service.yml
@@ -97,8 +97,6 @@ metadataDb:
   parameters:
     maxConnections: 100
 
-
-
 celeryBackend:
   port: 6379
   azMode: single-az


### PR DESCRIPTION
…flower

If your job is stuck here for more then 10 minutes, you probably have an issue with your deployment. The main causes for this is ECS tasks not being able to find the image definition on ECR, possibly caused by an autentication error between Docker and ECR.

Now if there was an issue while pushing the image, we will raise an error instead of continuing deployment.